### PR TITLE
use promhttp handler

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var defaultMetricPath = "/metrics"
@@ -109,7 +110,7 @@ func (p *Prometheus) handlerFunc() gin.HandlerFunc {
 }
 
 func prometheusHandler() gin.HandlerFunc {
-	h := prometheus.UninstrumentedHandler()
+	h := promhttp.Handler()
 	return func(c *gin.Context) {
 		h.ServeHTTP(c.Writer, c.Request)
 	}


### PR DESCRIPTION
`UninstrumentedHandler()` is deprecated per [Prometheus Documentation](https://godoc.org/github.com/prometheus/client_golang/prometheus#UninstrumentedHandler). This PR updates the middleware to use the new `promhttp` handler instead.